### PR TITLE
Adds cmake build setup to mathx_repl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 repl
 bin/
 test.mx
+
+# Build directories
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(MATHX_REPL CXX)
+
+
+# Force out-of-tree builds
+if("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
+   message(SEND_ERROR "In-source builds are not allowed.")
+endif("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
+
+# Include headers
+include_directories(include)
+
+# Add example folder
+add_subdirectory(src)

--- a/README.md
+++ b/README.md
@@ -4,11 +4,23 @@ REPL/Interpreter that works on top of MathX. It focuses to provide a simple inte
 
 ## Installation
 
+### Using Makefile
+
 1. (Optional) Install [mathx](www.github.com/math-x/mathx) for added functionality.
 2. Clone this repository using `git clone https;//github.com/math-x/mathx_repl`
 3. Change directory to the source `cd mathx_repl`
 4. Run the setup script using `./setup.sh`
 5. Run the REPL using the command `mathx` or `mathx -s` (silenced mode) or run a script using `mathx <path_to_script>`
+
+
+### Using cmake
+
+1. (Optional) Install [mathx](www.github.com/math-x/mathx) for added functionality.
+2. Clone this repository using `git clone https;//github.com/math-x/mathx_repl`
+3. Change directory to the source `cd mathx_repl`
+4. Create a build folder to build in and enter the directory `mkdir build && cd build`
+5. Invoke cmake to build repl `cmake ..`
+6. Run the REPL using the command `./mathx_repl` or `./mathx_repl -s` (silenced mode) or run a script using `./mathx_repl <path_to_script>`
 
 ## Examples
 	>>> 1+2

--- a/include/repl.h
+++ b/include/repl.h
@@ -1,7 +1,7 @@
 /*
  * MathX REPL
  * include/repl.h
- * Authors: Kanav Gupta
+ * Copyright (c) 2018 Kanav Gupta
  */
 
 #ifndef MATHX_REPL_

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,24 @@
+set(dependencies
+    assignment
+    error
+    evaluate
+    function_map
+    parser
+    process_file
+    run_repl
+    tools
+    variable_map
+)
+
+# Add math_repl components into a shared library
+add_library(repl SHARED ${dependencies})
+
+set(final_executable
+    main.cpp
+)
+
+# Set executable location to build directory
+set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR})
+
+add_executable(mathx_repl ${final_executable})
+target_link_libraries(mathx_repl repl)


### PR DESCRIPTION
It's been a while since I last had a look at this repo. Finally @kanav99 , I have added the cmake build you were asking for. Here are the key outlines:

[x] Force out of the tree build. This will ensure that our working tree is clean
[x] Adds portability
[x] No `sudo`, I'll add an install some other day to make it easier for someone to invoke math_repl ;)